### PR TITLE
add svd and other Mat extension methods with numpy-inspired names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / watchTriggeredMessage := Watch.clearScreenOnTrigger
 ThisBuild / scalaVersion  := scalaVer
 
 lazy val projectName = "uni"
-ThisBuild / version       := "0.8.0" // added numpy-like matrix to uni.data.*
+ThisBuild / version       := "0.8.1"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"


### PR DESCRIPTION
- def cumsum(axis: Int)(using num: Numeric[T]): Mat[T] 
- def cumsum(using num: Numeric[T]): Mat[T] 
- def cov(using frac: Fractional[T]): Mat[T] 
- def corrcoef(using frac: Fractional[T]): Mat[T] 
- def sort(axis: Int 
- def argsort(axis: Int 
- def unique(using ord: Ordering[T]): (Array[T], Array[Int]) 
- def svd(using frac: Fractional[T]): (Mat[T], Array[T], Mat[T]) 
- def lstsq(b: Mat[T])(using frac: Fractional[T]): (Mat[T], Mat[T], Int, Array[T]) 