### PR TITLE
final commit before release 0.9.1

### DIFF
--- a/docs/BigTypeGuide.md
+++ b/docs/BigTypeGuide.md
@@ -1,0 +1,82 @@
+# uni.data.Big Guide
+
+The ```Big``` type in ```uni.Mat``` is a high-precision numeric type designed to provide the accuracy of ```BigDecimal``` with the convenience of standard numeric types. It is implemented as a Scala 3 **Opaque Type**, ensuring zero-overhead at runtime while providing a safe, custom API.
+
+## Key Concept: BadNum (The BigDecimal NaN)
+
+Standard ```BigDecimal``` does not have a concept of "Not a Number" (NaN). If you divide by zero or encounter an invalid string, it throws an exception. ```uni.data.Big``` introduces ```BadNum```:
+
+* **Safe Arithmetic:** Operations involving ```BadNum``` result in ```BadNum``` (poisoning), similar to how ```Double.NaN``` works.
+* **Division Safety:** Dividing a ```Big``` value by zero returns ```BadNum``` instead of crashing your application.
+* **Validation:** Use ```n.isNaN``` or ```n.isNotNaN``` to check the validity of a result.
+
+## Usage
+
+### 1. Creation and Conversions
+
+You can create ```Big``` instances from strings, integers, longs, or doubles.
+
+```scala
+import uni.data.Big
+import uni.data.Big.*
+
+val b1 = big("123.456")  // From String
+val b2 = 100.asBig       // Extension method
+val b3: Big = 42.0       // Implicit conversion
+
+// Extraction
+val d: Double = b1.toDouble // Returns Double.NaN if b1 is BadNum
+```
+
+### 2. Arithmetic & Operators
+
+```Big``` supports all standard operators. If any operand is ```BadNum```, the result is ```BadNum```.
+
+```scala
+val result = (b1 + b2) * 2 / b3
+
+// Power operator (~^)
+val squared = b1 ~^ 2
+val root = b1 ~^ 0.5     // Fractional exponents use Double precision
+val preciseRoot = b1.sqrt // Precise BigDecimal square root
+```
+
+### 3. Comparison
+
+Comparisons are "BadNum-aware." Any comparison against a ```BadNum``` returns ```false```.
+
+```scala
+if (b1 > b2) {
+  println("Greater than")
+}
+```
+
+## API Reference
+
+### Construction
+| Method | Description |
+| :--- | :--- |
+| ```Big("1.23")``` | Safe parsing (returns ```BadNum``` on failure) |
+| ```big(1.23)``` | Lowercase factory method |
+| ```.asBig``` | Extension method for ```Int```, ```Long```, and ```Double``` |
+
+### Safety Checks
+| Method | Description |
+| :--- | :--- |
+| ```n.isNaN``` | Returns true if the value is ```BadNum``` |
+| ```n.isNotNaN``` | Returns true if the value is a valid number |
+| ```unapply(n)``` | Allows pattern matching: ```case Big(value) => ...``` |
+
+### Precision & Formatting
+| Method | Description |
+| :--- | :--- |
+| ```n.setScale(s, mode)``` | Adjusts decimal places with a ```RoundingMode``` |
+| ```n.toPlainString``` | Formats without scientific notation |
+| ```n.sqrt``` | High-precision square root using ```DECIMAL128``` context |
+
+## Why use Big instead of Double?
+
+Use ```Big``` when **precision is non-negotiable** (e.g., Financial calculations, high-precision weights, or any domain where floating-point rounding errors are unacceptable), but you still want the "safety-first" coding style of the NumPy/Mat ecosystem.
+
+---
+© 2026 VastBlue.

--- a/jsrc/loadCsv.sc
+++ b/jsrc/loadCsv.sc
@@ -1,0 +1,35 @@
+#!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
+
+//> using dep org.vastblue:uni_3:0.9.1
+
+import uni.*
+import uni.data.*
+
+object LoadCsv {
+ def usage(m: String = ""): Nothing = {
+    showUsage(m, "",
+      "<filename>    ; input",
+    )
+  }
+
+  var verbose = false
+  var infile = ""
+  def main(args: Array[String]): Unit = {
+    eachArg(args.toSeq, usage) {
+    case "-v" => verbose = true
+    case f if f.path.isFile =>
+      infile = f
+    case arg =>
+      usage(s"unrecognized arg [$arg]")
+    }
+    if infile.isEmpty then
+      usage()
+    val p = infile.path
+    if !p.isFile then
+      usage(s"not found: ${p.posx}")
+
+    val data = p.loadMat(big(_))
+    val filtered = data.filterRows(_.isNotNaN.any)
+    println(filtered)
+  }
+}

--- a/jsrc/matD.sc
+++ b/jsrc/matD.sc
@@ -1,0 +1,31 @@
+#!/usr/bin/env -S scala-cli shebang -deprecation
+
+//> using dep org.vastblue:uni_3:0.9.1
+
+import uni.data.*
+//import uni.data.Mat.*
+
+var m = MatD.zeros(3, 4)
+println(s"m: $m")
+var col_ = m(::, 0)
+var sub = m(0 until 2, ::)
+var row_ = m(0, ::)
+var step = m(0 until m.rows by 2, ::)
+var flat = m.flatten
+var reshaped = m.reshape(2, 6)
+var transposed = m.T
+var stacked = MatD.vstack(w, eye)
+var hstacked = MatD.hstack(w, eye)
+var result2 = MatD.where(v.gt(0), v, -v)
+var rand_m = MatD.rand(3, 3)
+var randn_m = MatD.randn(3, 3)
+var med = v.median
+var pct = v.percentile(75)
+def normalize(x: MatD): MatD = {
+  x - x.mean / x.std
+}
+for i <- 0 until 3 do
+  m(i, ::) = i * 2
+m :+= 1
+m :*= 2
+print(result.show)

--- a/src/main/scala/uni/data/MatFormat.scala
+++ b/src/main/scala/uni/data/MatFormat.scala
@@ -1,0 +1,251 @@
+package uni.data
+
+def formatMatrix[T](
+  tdata: Array[T],
+  rows: Int,
+  cols: Int,
+  offset: Int,
+  rs: Int,
+  cs: Int,
+  typeName: String,
+  toDouble: T => Double,
+  mkString: T => String,
+  fmt: Option[String] = None
+): String = {
+
+  def getValue(i: Int, j: Int): T =
+    tdata(offset + i * rs + j * cs)
+
+  // Truncation thresholds
+  val maxRows = Mat.PrintOptions.maxRows
+  val maxCols = Mat.PrintOptions.maxCols
+  val edgeRows = Mat.PrintOptions.edgeItems
+  val edgeCols = Mat.PrintOptions.edgeItems
+
+  val truncateRows = rows > maxRows
+  val truncateCols = cols > maxCols
+
+  // Determine which indices to display
+  val rowIndices = if (truncateRows) {
+    (0 until edgeRows) ++ (rows - edgeRows until rows)
+  } else {
+    0 until rows
+  }
+
+  val colIndices = if (truncateCols) {
+    (0 until edgeCols) ++ (cols - edgeCols until cols)
+  } else {
+    0 until cols
+  }
+
+  val displayRows = rowIndices.size
+  val displayCols = colIndices.size
+
+  // Helper to trim zeros
+  def trimZeros(s: String, keepDecimal: Boolean): String = {
+    val parts = s.split("[eE]", 2)
+    val main  = parts(0)
+    val exp   = if (parts.length == 2) "e" + parts(1) else ""
+
+    val trimmedMain =
+      if (main.contains('.')) {
+        val r = main.reverse.dropWhile(_ == '0').dropWhile(_ == '.').reverse
+        if (r.isEmpty) "0"
+        else if (keepDecimal && !r.contains('.')) r + "."
+        else r
+      } else main
+    trimmedMain + exp
+  }
+
+  // Automatic formatting with high precision
+  def renderAuto: String = {
+    val values =
+      for (i <- rowIndices; j <- colIndices)
+      yield toDouble(getValue(i, j))
+
+    if (values.isEmpty) {
+      ""
+    } else {
+      val absMax = values.map(math.abs).max
+      val absMin = values.filter(_ != 0.0).map(math.abs).minOption.getOrElse(0.0)
+
+      val sci = absMax >= 1e8 || (absMin > 0 && absMin < 1e-6)
+
+      val base =
+        if (displayCols <= 4) 10
+        else if (displayCols <= 8) 8
+        else 6
+
+      val spread = values.max - values.min
+
+      val maxDec =
+        if (sci) base
+        else if (spread == 0.0) base
+        else if (spread >= 100) base - 3
+        else if (spread >= 10) base - 2
+        else if (spread >= 1) base - 1
+        else base
+
+      val fmtStr = if (sci) s"%.${maxDec}e" else s"%.${maxDec}f"
+      val raw = values.map(v => fmtStr.format(v)).toIndexedSeq
+      renderRowsFromRaw(raw, isAuto = true)
+    }
+  }
+
+  // Format with explicit format string
+  def renderRows(fmtStr: String): String = {
+    val isAuto = fmtStr.isEmpty
+
+    val raw =
+      if (isAuto) {
+        for (i <- rowIndices; j <- colIndices)
+        yield mkString(getValue(i, j))
+      } else {
+        for (i <- rowIndices; j <- colIndices)
+        yield fmtStr.format(getValue(i, j))
+      }
+    renderRowsFromRaw(raw, isAuto)
+  }
+
+  // Core rendering logic
+  def renderRowsFromRaw(raw: IndexedSeq[String], isAuto: Boolean): String = {
+    val colHasDecimal = Array.fill(displayCols)(false)
+    for (i <- 0 until displayRows; j <- 0 until displayCols) {
+      if (raw(i * displayCols + j).contains('.')) {
+        colHasDecimal(j) = true
+      }
+    }
+
+    // 1. Guard against parsing non-numeric strings like "true"/"false"
+    val values =
+      if (raw.isEmpty || typeName == "Boolean") Nil
+      else raw.map(s => scala.util.Try(s.toDouble).getOrElse(0.0)).map(math.abs)
+
+    // 2. Only check for scientific notation if we actually have numeric values
+    val useSci =
+      if (values.isEmpty || typeName == "Boolean") {
+        false
+      } else {
+        val absMax = values.max
+        val absMin = values.filter(_ > 0).minOption.getOrElse(absMax)
+        absMax >= 1e8 || absMin < 1e-6
+      }
+
+    val colIsInteger =
+      if (isAuto) {
+        if (useSci) {
+          Array.fill(displayCols)(false)
+        } else {
+          val arr = Array.fill(displayCols)(true)
+          for (i <- 0 until displayRows; j <- 0 until displayCols) {
+            val d = toDouble(getValue(rowIndices(i), colIndices(j)))
+            if (d != Math.rint(d)) {
+              arr(j) = false
+            }
+          }
+          arr
+        }
+      } else {
+        Array.fill(displayCols)(false)
+      }
+
+    for (j <- 0 until displayCols) {
+      if (colIsInteger(j)) {
+        colHasDecimal(j) = false
+      }
+    }
+
+    val trimmed =
+      if (isAuto) {
+        for (idx <- raw.indices) yield {
+          val col = idx % displayCols
+          if (colIsInteger(col)) {
+            val s = raw(idx)
+            val dot = s.indexOf('.')
+            if (dot >= 0) s.substring(0, dot)
+            else s
+          } else {
+            val t0 = trimZeros(raw(idx), keepDecimal = colHasDecimal(col))
+            if (colHasDecimal(col)) {
+              if (t0.contains('.')) {
+                if (t0.endsWith(".")) t0 + "0" else t0
+              } else {
+                t0 + ".0"
+              }
+            } else {
+              t0
+            }
+          }
+        }
+      } else {
+        raw
+      }
+
+    val split =
+      trimmed.map(_.stripLeading).map { s =>
+        val parts = s.split("\\.", 2)
+        if (parts.length == 1) (parts(0), "")
+        else (parts(0), parts(1))
+      }
+
+    val intWidth  = Array.fill(displayCols)(0)
+    val fracWidth = Array.fill(displayCols)(0)
+
+    for (i <- 0 until displayRows; j <- 0 until displayCols) {
+      val (intp, fracp) = split(i * displayCols + j)
+      intWidth(j)  = math.max(intWidth(j),  intp.length)
+      fracWidth(j) = math.max(fracWidth(j), fracp.length)
+    }
+
+    // Add ellipsis column widths if truncating columns
+    val sb = new StringBuilder
+    var idx = 0
+
+    for (displayRowIdx <- 0 until displayRows) {
+      // Insert row ellipsis after edge rows
+      if (truncateRows && displayRowIdx == edgeRows) {
+        sb.append(" ...\n")
+      }
+
+      sb.append(" (")
+      for (displayColIdx <- 0 until displayCols) {
+        // Insert column ellipsis after edge cols
+        if (truncateCols && displayColIdx == edgeCols) {
+          sb.append("...")
+          if (displayColIdx < displayCols - 1) sb.append(", ")
+        }
+
+        val (intp, fracp) = split(idx)
+        sb.append(" " * (intWidth(displayColIdx) - intp.length))
+        sb.append(intp)
+
+        if (colHasDecimal(displayColIdx)) {
+          sb.append(".")
+          sb.append(fracp)
+          sb.append(" " * (fracWidth(displayColIdx) - fracp.length))
+        }
+
+        if (displayColIdx < displayCols - 1) sb.append(", ")
+        idx += 1
+      }
+      sb.append(")")
+      if (displayRowIdx < displayRows - 1) sb.append(",\n")
+    }
+
+    sb.toString
+  }
+
+  val header = s"${rows}x${cols} Mat[$typeName]:"
+  val body =
+  if (fmt.isDefined) {
+    renderRows(fmt.get)
+  } else if (typeName == "Boolean" || typeName == "Big") {
+    renderRows("") // Passing empty string triggers the isAuto logic in renderRows
+  } else {
+    renderAuto
+  }
+
+  if (body.isEmpty) header
+  else s"$header\n$body"
+
+}

--- a/src/test/scala/uni/data/BigCoverageSuite.scala
+++ b/src/test/scala/uni/data/BigCoverageSuite.scala
@@ -1,0 +1,418 @@
+package uni.data
+
+import munit.FunSuite
+import uni.data.Big
+import uni.data.Big.*
+import uni.data.BigUtils.*
+
+/** Extended coverage for the Big opaque type, covering constructors, mixed-type
+ *  arithmetic, conversions, comparisons with primitives, BigNaN propagation,
+ *  math ops, and the Numeric/Fractional typeclasses. */
+class BigCoverageSuite extends FunSuite {
+
+  // ============================================================================
+  // Constructors
+  // ============================================================================
+
+  test("Big(Int) constructs correctly") {
+    assertEquals(Big(42).value, BigDecimal(42))
+    assertEquals(Big(0).value, BigDecimal(0))
+    assertEquals(Big(-7).value, BigDecimal(-7))
+  }
+
+  test("Big(Long) constructs correctly") {
+    assertEquals(Big(123456789L).value, BigDecimal(123456789L))
+    assertEquals(Big(Long.MaxValue).value, BigDecimal(Long.MaxValue))
+  }
+
+  test("Big(Double) constructs correctly") {
+    assertEquals(Big(3.14).value, BigDecimal(3.14))
+    assertEquals(Big(0.0).value, BigDecimal(0.0))
+  }
+
+  test("Big(BigDecimal) constructs correctly") {
+    val bd = BigDecimal("9999999999999999.99")
+    assertEquals(Big(bd).value, bd)
+  }
+
+  // ============================================================================
+  // Named constants
+  // ============================================================================
+
+  test("Big constants: zero, one, ten, hundred") {
+    assertEquals(Big.zero.value, BigDecimal(0))
+    assertEquals(Big.one.value,  BigDecimal(1))
+    assertEquals(Big.ten.value,  BigDecimal(10))
+    assertEquals(Big.hundred.value, BigDecimal(100))
+  }
+
+  // ============================================================================
+  // Lowercase factory (big)
+  // ============================================================================
+
+  test("Big.big factory mirrors apply") {
+    assertEquals(Big.big("12.5").value, BigDecimal("12.5"))
+    assertEquals(Big.big(3),            Big(3))
+    assertEquals(Big.big(4L),           Big(4L))
+    assertEquals(Big.big(1.5),          Big(1.5))
+    assertEquals(Big.big(BigDecimal(7)), Big(BigDecimal(7)))
+  }
+
+  // ============================================================================
+  // asBig / toBig extension methods
+  // ============================================================================
+
+  test("Double.asBig / Long.asBig / Int.asBig") {
+    assertEquals((3.14).asBig.value, BigDecimal(3.14))
+    assertEquals((100L).asBig.value, BigDecimal(100L))
+    assertEquals((5).asBig.value,    BigDecimal(5))
+  }
+
+  test("Double.toBig") {
+    assertEquals((2.5).toBig.value, BigDecimal(2.5))
+  }
+
+  // ============================================================================
+  // Implicit widening conversions
+  // ============================================================================
+
+  test("Int widens to Big implicitly") {
+    val b: Big = 7
+    assertEquals(b.value, BigDecimal(7))
+  }
+
+  test("Long widens to Big implicitly") {
+    val b: Big = 100L
+    assertEquals(b.value, BigDecimal(100L))
+  }
+
+  test("Double widens to Big implicitly") {
+    val b: Big = 1.5
+    assertEquals(b.value, BigDecimal(1.5))
+  }
+
+  test("Float widens to Big implicitly") {
+    val b: Big = 2.0f
+    assertEquals(b.value, BigDecimal(2.0f))
+  }
+
+  // ============================================================================
+  // Mixed-type arithmetic: Big op primitive
+  // ============================================================================
+
+  test("Big + Int/Long/Double") {
+    val b = Big(10)
+    assertEquals((b + 3).value,    BigDecimal(13))
+    assertEquals((b + 3L).value,   BigDecimal(13))
+    assertEquals((b + 1.5).value,  BigDecimal("11.5"))
+  }
+
+  test("Big - Int/Long/Double") {
+    val b = Big(10)
+    assertEquals((b - 3).value,    BigDecimal(7))
+    assertEquals((b - 3L).value,   BigDecimal(7))
+    assertEquals((b - 1.5).value,  BigDecimal("8.5"))
+  }
+
+  test("Big * Int/Long/Double") {
+    val b = Big(4)
+    assertEquals((b * 3).value,    BigDecimal(12))
+    assertEquals((b * 3L).value,   BigDecimal(12))
+    assertEquals((b * 2.5).value,  BigDecimal("10.0"))
+  }
+
+  test("Big / Int (non-zero)") {
+    assertEquals((Big(9) / 3).value, BigDecimal(3))
+  }
+
+  test("Big / Long (non-zero)") {
+    assertEquals((Big(8) / 2L).value, BigDecimal(4))
+  }
+
+  test("Big / Double (non-zero)") {
+    assertEqualsDouble((Big(5) / 2.0).toDouble, 2.5, 1e-12)
+  }
+
+  // ============================================================================
+  // Mixed-type division edge cases → BigNaN
+  // ============================================================================
+
+  test("Big / 0 (Int) returns BigNaN") {
+    assertEquals(Big(10) / 0, BigNaN)
+  }
+
+  test("Big / 0L (Long) returns BigNaN") {
+    assertEquals(Big(10) / 0L, BigNaN)
+  }
+
+  test("Big / 0.0 (Double) returns BigNaN") {
+    assertEquals(Big(10) / 0.0, BigNaN)
+  }
+
+  test("Big / NaN (Double) returns BigNaN") {
+    val divideByNan = Big(10) / Double.NaN
+    assertEquals(divideByNan, BigNaN)
+  }
+
+  test("Big / Infinity (Double) returns BigNaN") {
+    assertEquals(Big(10) / Double.PositiveInfinity, BigNaN)
+  }
+
+  // ============================================================================
+  // BigNaN propagation in mixed arithmetic
+  // ============================================================================
+
+  test("BigNaN + Int propagates BigNaN") {
+    assertEquals(BigNaN + 5, BigNaN)
+  }
+
+  test("BigNaN - Long propagates BigNaN") {
+    assertEquals(BigNaN - 5L, BigNaN)
+  }
+
+  test("BigNaN * Double propagates BigNaN") {
+    assertEquals(BigNaN * 2.0, BigNaN)
+  }
+
+  // ============================================================================
+  // Unary negation
+  // ============================================================================
+
+  test("unary - negates a valid Big") {
+    assertEquals((-Big(5)).value, BigDecimal(-5))
+    assertEquals((-Big(-3)).value, BigDecimal(3))
+  }
+
+  test("unary - on BigNaN returns BigNaN") {
+    assertEquals(-BigNaN, BigNaN)
+  }
+
+  // ============================================================================
+  // Comparisons with primitives
+  // ============================================================================
+
+  test("Big < Double / Long / Int") {
+    assert(Big(1) < 2.0)
+    assert(Big(1) < 2L)
+    assert(Big(1) < 2)
+  }
+
+  test("Big <= Double / Long / Int") {
+    assert(Big(2) <= 2.0)
+    assert(Big(2) <= 2L)
+    assert(Big(2) <= 2)
+  }
+
+  test("Big > Double / Long / Int") {
+    assert(Big(3) > 2.0)
+    assert(Big(3) > 2L)
+    assert(Big(3) > 2)
+  }
+
+  test("Big >= Double / Long / Int") {
+    assert(Big(2) >= 2.0)
+    assert(Big(2) >= 2L)
+    assert(Big(2) >= 2)
+  }
+
+  // ============================================================================
+  // BigNaN short-circuits comparisons (no exception)
+  // ============================================================================
+
+  test("BigNaN comparisons all return false") {
+    assert(!(BigNaN < Big(1)))
+    assert(!(BigNaN <= Big(1)))
+    assert(!(BigNaN > Big(1)))
+    assert(!(BigNaN >= Big(1)))
+    assert(!(Big(1) < BigNaN))
+    assert(!(Big(1) > BigNaN))
+  }
+
+  // ============================================================================
+  // Conversions
+  // ============================================================================
+
+  test("toDouble / toFloat / toInt / toLong on valid Big") {
+    val b = Big(42)
+    assertEqualsDouble(b.toDouble, 42.0, 1e-12)
+    assertEquals(b.toFloat,  42.0f)
+    assertEquals(b.toInt,    42)
+    assertEquals(b.toLong,   42L)
+  }
+
+  test("toDouble on BigNaN returns Double.NaN") {
+    assert(BigNaN.toDouble.isNaN)
+  }
+
+  test("toFloat on BigNaN returns Float.NaN") {
+    assert(BigNaN.toFloat.isNaN)
+  }
+
+  test("toBig is identity") {
+    val b = Big(7)
+    assertEquals(b.toBig, b)
+  }
+
+  test("toBigDecimal unwraps to underlying BigDecimal") {
+    val b = Big(3)
+    assertEquals(b.toBigDecimal, BigDecimal(3))
+  }
+
+  // ============================================================================
+  // isNaN / isNotNaN
+  // ============================================================================
+
+  test("isNaN is true only for BigNaN") {
+    assert(BigNaN.isNaN)
+    assert(!Big(0).isNaN)
+    assert(!Big(42).isNaN)
+  }
+
+  test("isNotNaN is false only for BigNaN") {
+    assert(!BigNaN.isNotNaN)
+    assert(Big(1).isNotNaN)
+  }
+
+  // ============================================================================
+  // abs
+  // ============================================================================
+
+  test("abs returns absolute value") {
+    assertEquals(Big(-5).abs.value,  BigDecimal(5))
+    assertEquals(Big(5).abs.value,   BigDecimal(5))
+    assertEquals(Big(0).abs.value,   BigDecimal(0))
+  }
+
+  // ============================================================================
+  // signum
+  // ============================================================================
+
+  test("signum returns -1 / 0 / 1") {
+    assertEquals(Big(-3).signum, -1)
+    assertEquals(Big(0).signum,   0)
+    assertEquals(Big(7).signum,   1)
+  }
+
+  // ============================================================================
+  // sqrt
+  // ============================================================================
+
+  test("sqrt of perfect square is exact") {
+    assertEqualsDouble(Big(4).sqrt.toDouble,   2.0,  1e-10)
+    assertEqualsDouble(Big(9).sqrt.toDouble,   3.0,  1e-10)
+    assertEqualsDouble(Big(100).sqrt.toDouble, 10.0, 1e-10)
+  }
+
+  test("sqrt of non-square is high precision") {
+    assertEqualsDouble(Big(2).sqrt.toDouble, math.sqrt(2), 1e-10)
+  }
+
+  // ============================================================================
+  // ~^ power operator
+  // ============================================================================
+
+  test("~^ with Int exponent is exact") {
+    assertEquals((Big(2) ~^ 10).value, BigDecimal(1024))
+    assertEquals((Big(3) ~^ 3).value,  BigDecimal(27))
+    assertEquals((Big(5) ~^ 0).value,  BigDecimal(1))
+  }
+
+  test("~^ with Long exponent is exact") {
+    assertEquals((Big(2) ~^ 10L).value, BigDecimal(1024))
+  }
+
+  test("~^ with Float exponent (whole number) is exact") {
+    assertEquals((Big(2) ~^ 8.0f).value, BigDecimal(256))
+  }
+
+  test("~^ with Double exponent (whole number) is exact") {
+    assertEquals((Big(2) ~^ 10.0).value, BigDecimal(1024))
+  }
+
+  test("~^ with BigDecimal exponent (whole number) is exact") {
+    assertEquals((Big(2) ~^ BigDecimal(10)).value, BigDecimal(1024))
+  }
+
+  test("~^ with Big exponent (whole number) is exact") {
+    assertEquals((Big(2) ~^ Big(10)).value, BigDecimal(1024))
+  }
+
+  test("~^ with fractional Double exponent uses double fallback") {
+    assertEqualsDouble((Big(4) ~^ 0.5).toDouble, 2.0, 1e-9)
+    assertEqualsDouble((Big(8) ~^ (1.0/3)).toDouble, 2.0, 1e-9)
+  }
+
+  test("~^ with fractional Big exponent uses double fallback") {
+    assertEqualsDouble((Big(4) ~^ Big(0.5)).toDouble, 2.0, 1e-9)
+  }
+
+  // ============================================================================
+  // toPlainString
+  // ============================================================================
+
+  test("toPlainString avoids scientific notation") {
+    val b = Big(1000000000L)
+    assert(!b.toPlainString.contains("E"), s"expected plain, got: ${b.toPlainString}")
+    assertEquals(b.toPlainString, "1000000000")
+  }
+
+  // ============================================================================
+  // unapply extractor
+  // ============================================================================
+
+  test("Big extractor matches valid values") {
+    val result = Big(42) match
+      case Big(v) => v.toDouble
+      case _      => -1.0
+    assertEqualsDouble(result, 42.0, 1e-12)
+  }
+
+  test("Big extractor does not match BigNaN") {
+    val result = BigNaN match
+      case Big(_) => "matched"
+      case _      => "no match"
+    assertEquals(result, "no match")
+  }
+
+  // ============================================================================
+  // Numeric[Big] typeclass
+  // ============================================================================
+
+  test("Numeric[Big].fromInt") {
+    val num = summon[Numeric[Big]]
+    assertEquals(num.fromInt(7), Big(7))
+  }
+
+  test("Numeric[Big].negate") {
+    val num = summon[Numeric[Big]]
+    assertEquals(num.negate(Big(5)), Big(-5))
+  }
+
+//  test("Numeric[Big].parseString") {
+//    val num = summon[Numeric[Big]]
+//    assertEquals(num.parseString("3.14").map(_.toDouble).getOrElse(-1.0), 3.14, 1e-12)
+//    assert(num.parseString("bad").isNaN)
+//  }
+
+  test("Numeric[Big].compare") {
+    val num = summon[Numeric[Big]]
+    assert(num.compare(Big(1), Big(2)) < 0)
+    assert(num.compare(Big(2), Big(2)) == 0)
+    assert(num.compare(Big(3), Big(2)) > 0)
+  }
+
+  // ============================================================================
+  // isValidInt / isValidLong
+  // ============================================================================
+
+  test("isValidInt true for small integers, false for large or fractional") {
+    assert(Big(42).isValidInt)
+    assert(!Big(1e18.toLong + 1).isValidInt)
+    assert(!Big(3.14).isValidInt)
+  }
+
+  test("isValidLong true for long-range integers") {
+    assert(Big(Long.MaxValue).isValidLong)
+    assert(!Big(3.14).isValidLong)
+  }
+}

--- a/src/test/scala/uni/data/BigSuite.scala
+++ b/src/test/scala/uni/data/BigSuite.scala
@@ -28,9 +28,9 @@ final class BigSuite extends FunSuite:
     assertEquals(BG("1,234.56").value, BD("1234.56"))
   }
 
-  test("Big.apply returns BadNum for invalid strings") {
-    assertEquals(BG("abc"), BadNum)
-    assertEquals(BG("12x34"), BadNum)
+  test("Big.apply returns BigNaN for invalid strings") {
+    assertEquals(BG("abc"), BigNaN)
+    assertEquals(BG("12x34"), BigNaN)
   }
 
   // ------------------------------------------------------------
@@ -47,13 +47,13 @@ final class BigSuite extends FunSuite:
     assertEquals((a / b).value, BigDecimal("4.0"))
   }
 
-  test("Arithmetic with BadNum propagates BadNum") {
+  test("Arithmetic with BigNaN propagates BigNaN") {
     val bad = BG("not-a-number")
     val good = BG("10")
 
-    assertEquals((bad + good), BadNum)
-    assertEquals((good + bad), BadNum)
-    assertEquals((bad * bad), BadNum)
+    assertEquals((bad + good), BigNaN)
+    assertEquals((good + bad), BigNaN)
+    assertEquals((bad * bad), BigNaN)
   }
 
   // ------------------------------------------------------------
@@ -77,8 +77,8 @@ final class BigSuite extends FunSuite:
     assertEquals(s.trim, "123.5")
   }
 
-  test("numStr handles BadNum") {
-    val s = numStr(BadNum)
+  test("numStr handles BigNaN") {
+    val s = numStr(BigNaN)
     assert(s.contains("N/A"))
   }
 
@@ -101,7 +101,7 @@ final class BigSuite extends FunSuite:
   }
 
   test("str2num rejects invalid characters") {
-    assertEquals(str2num("12a3"), BadNum)
+    assertEquals(str2num("12a3"), BigNaN)
   }
 
   // ------------------------------------------------------------
@@ -169,7 +169,7 @@ final class BigSuite extends FunSuite:
   test("divide by zero returns None") {
     val ten = Big(10)
     val chek = ten / Big.zero
-    assertEquals(chek, BadNum)  // Tests the None branch
+    assertEquals(chek, BigNaN)  // Tests the None branch
   }
 
   test("divide non-zero returns Some") {

--- a/src/test/scala/uni/data/MatAliasSuite.scala
+++ b/src/test/scala/uni/data/MatAliasSuite.scala
@@ -1,0 +1,403 @@
+package uni.data
+
+import munit.FunSuite
+import uni.data.Big
+import uni.data.Big.*
+
+/** Tests for MatD / MatB / MatF facade objects and their type aliases. */
+class MatAliasSuite extends FunSuite {
+
+  // ============================================================================
+  // MatD
+  // ============================================================================
+
+  test("MatD type alias is Mat[Double]") {
+    val m: MatD = MatD.zeros(2, 3)
+    assertEquals(m.rows, 2)
+    assertEquals(m.cols, 3)
+    assertEquals(m(0, 0), 0.0)
+  }
+
+  test("MatD.ones / eye / full") {
+    val o = MatD.ones(2, 2)
+    assertEquals(o(0, 0), 1.0)
+
+    val e = MatD.eye(3)
+    assertEquals(e(0, 0), 1.0)
+    assertEquals(e(0, 1), 0.0)
+
+    val f = MatD.full(2, 2, 5.0)
+    assertEquals(f(1, 1), 5.0)
+  }
+
+  test("MatD.arange / linspace") {
+    val a = MatD.arange(5)
+    assertEquals(a.shape, (5, 1))
+    assertEquals(a(4, 0), 4.0)
+
+    val l = MatD.linspace(0.0, 1.0, 5)
+    assertEquals(l.shape, (5, 1))
+    assertEqualsDouble(l(4, 0), 1.0, 1e-12)
+  }
+
+  test("MatD.of / row / col / fromSeq / single") {
+    val o = MatD.of(1.0, 2.0, 3.0)
+    assertEquals(o.shape, (1, 3))
+    assertEquals(o(0, 1), 2.0)
+
+    val r = MatD.row(4.0, 5.0)
+    assertEquals(r.shape, (1, 2))
+
+    val c = MatD.col(6.0, 7.0)
+    assertEquals(c.shape, (2, 1))
+
+    val fs = MatD.fromSeq(Seq(1.0, 2.0, 3.0))
+    assertEquals(fs.shape, (3, 1))
+
+    val s = MatD.single(9.0)
+    assertEquals(s.shape, (1, 1))
+    assertEquals(s(0, 0), 9.0)
+  }
+
+  test("MatD.tabulate") {
+    val m = MatD.tabulate(2, 3)((i, j) => (i * 3 + j).toDouble)
+    assertEquals(m(0, 0), 0.0)
+    assertEquals(m(1, 2), 5.0)
+  }
+
+  test("MatD.diag") {
+    val d = MatD.diag(Array(1.0, 2.0, 3.0))
+    assertEquals(d.shape, (3, 3))
+    assertEquals(d(0, 0), 1.0)
+    assertEquals(d(1, 1), 2.0)
+    assertEquals(d(0, 1), 0.0)
+  }
+
+  test("MatD.zerosLike / onesLike / fullLike") {
+    val src = MatD.full(2, 3, 7.0)
+    assertEquals(MatD.zerosLike(src)(0, 0), 0.0)
+    assertEquals(MatD.onesLike(src)(0, 0), 1.0)
+    assertEquals(MatD.fullLike(src, 3.0)(1, 2), 3.0)
+  }
+
+  test("MatD.vstack / hstack / concatenate") {
+    val a = MatD.ones(2, 3)
+    val b = MatD.zeros(2, 3)
+    val vs = MatD.vstack(a, b)
+    assertEquals(vs.shape, (4, 3))
+    assertEquals(vs(0, 0), 1.0)
+    assertEquals(vs(2, 0), 0.0)
+
+    val hs = MatD.hstack(a, b)
+    assertEquals(hs.shape, (2, 6))
+
+    val cc = MatD.concatenate(Seq(a, b), axis = 0)
+    assertEquals(cc.shape, (4, 3))
+  }
+
+  test("MatD.where (mat and scalar overloads)") {
+    val eye   = MatD.eye(2)
+    val cond  = eye.map(_ == 1.0)   // Mat[Boolean]: true on diagonal
+    val wm    = MatD.where(cond, MatD.full(2, 2, 9.0), MatD.zeros(2, 2))
+    assertEquals(wm(0, 0), 9.0)
+    assertEquals(wm(0, 1), 0.0)
+
+    val ws = MatD.where(cond, 9.0, 0.0)
+    assertEquals(ws(0, 0), 9.0)
+    assertEquals(ws(0, 1), 0.0)
+  }
+
+  test("MatD.setSeed / rand / randn / uniform / normal shapes") {
+    MatD.setSeed(42L)
+    val r  = MatD.rand(4, 5);   assertEquals(r.shape,  (4, 5))
+    val rn = MatD.randn(3, 3);  assertEquals(rn.shape, (3, 3))
+    val u  = MatD.uniform(-1.0, 1.0, 2, 4); assertEquals(u.shape, (2, 4))
+    val n  = MatD.normal(0.0, 1.0, 3, 2);   assertEquals(n.shape, (3, 2))
+  }
+
+  test("MatD.rand values are in [0, 1)") {
+    MatD.setSeed(0L)
+    val m = MatD.rand(10, 10)
+    m.foreach(v => assert(v >= 0.0 && v < 1.0, s"out of range: $v"))
+  }
+
+  test("MatD.uniform values are in [low, high)") {
+    MatD.setSeed(1L)
+    val m = MatD.uniform(-5.0, 5.0, 10, 10)
+    m.foreach(v => assert(v >= -5.0 && v < 5.0, s"out of range: $v"))
+  }
+
+  test("MatD.randint (scalar and matrix)") {
+    MatD.setSeed(7L)
+    val i = MatD.randint(0, 10)
+    assert(i >= 0 && i < 10, s"out of range: $i")
+
+    val m = MatD.randint(0, 5, 3, 3)
+    assertEquals(m.shape, (3, 3))
+    m.foreach(v => assert(v >= 0 && v < 5, s"out of range: $v"))
+  }
+
+  test("MatD.setSeed produces deterministic rand") {
+    MatD.setSeed(123L)
+    val a = MatD.rand(2, 2)
+    MatD.setSeed(123L)
+    val b = MatD.rand(2, 2)
+    assertEquals(a(0, 0), b(0, 0))
+    assertEquals(a(1, 1), b(1, 1))
+  }
+
+  // ============================================================================
+  // MatB
+  // ============================================================================
+
+  test("MatB type alias is Mat[Big]") {
+    val m: MatB = MatB.zeros(2, 3)
+    assertEquals(m.rows, 2)
+    assertEquals(m.cols, 3)
+    assertEquals(m(0, 0), Big(0))
+  }
+
+  test("MatB.ones / eye / full") {
+    val o = MatB.ones(2, 2)
+    assertEquals(o(0, 0), Big(1))
+
+    val e = MatB.eye(3)
+    assertEquals(e(0, 0), Big(1))
+    assertEquals(e(0, 1), Big(0))
+
+    val f = MatB.full(2, 2, 5.0)
+    assertEquals(f(1, 1), Big(5))
+  }
+
+  test("MatB.arange / linspace") {
+    val a = MatB.arange(4)
+    assertEquals(a.shape, (4, 1))
+    assertEquals(a(3, 0), Big(3))
+
+    val l = MatB.linspace(0.0, 1.0, 3)
+    assertEquals(l.shape, (3, 1))
+  }
+
+  test("MatB.of / row / col / fromSeq / single") {
+    val o = MatB.of(1.0, 2.0, 3.0)
+    assertEquals(o.shape, (1, 3))
+    assertEquals(o(0, 1), Big(2))
+
+    val r = MatB.row(4.0, 5.0)
+    assertEquals(r.shape, (1, 2))
+
+    val c = MatB.col(6.0, 7.0)
+    assertEquals(c.shape, (2, 1))
+
+    val fs = MatB.fromSeq(Seq(Big(1), Big(2)))
+    assertEquals(fs.shape, (2, 1))
+
+    val s = MatB.single(9.0)
+    assertEquals(s(0, 0), Big(9))
+  }
+
+  test("MatB.tabulate") {
+    val m = MatB.tabulate(2, 3)((i, j) => Big(i * 3 + j))
+    assertEquals(m(0, 0), Big(0))
+    assertEquals(m(1, 2), Big(5))
+  }
+
+  test("MatB.diag") {
+    val d = MatB.diag(Array(Big(1), Big(2), Big(3)))
+    assertEquals(d.shape, (3, 3))
+    assertEquals(d(1, 1), Big(2))
+    assertEquals(d(0, 1), Big(0))
+  }
+
+  test("MatB.zerosLike / onesLike / fullLike") {
+    val src = MatB.full(2, 3, 7.0)
+    assertEquals(MatB.zerosLike(src)(0, 0), Big(0))
+    assertEquals(MatB.onesLike(src)(0, 0), Big(1))
+  }
+
+  test("MatB.vstack / hstack") {
+    val a = MatB.ones(2, 3)
+    val b = MatB.zeros(2, 3)
+    val vs = MatB.vstack(a, b)
+    assertEquals(vs.shape, (4, 3))
+    assertEquals(vs(0, 0), Big(1))
+    assertEquals(vs(2, 0), Big(0))
+
+    val hs = MatB.hstack(a, b)
+    assertEquals(hs.shape, (2, 6))
+  }
+
+  test("MatB.setSeed / rand / randn / uniform / normal shapes") {
+    MatB.setSeed(42L)
+    val r  = MatB.rand(4, 5);   assertEquals(r.shape,  (4, 5))
+    val rn = MatB.randn(3, 3);  assertEquals(rn.shape, (3, 3))
+    val u  = MatB.uniform(-1.0, 1.0, 2, 4); assertEquals(u.shape, (2, 4))
+    val n  = MatB.normal(0.0, 1.0, 3, 2);   assertEquals(n.shape, (3, 2))
+  }
+
+  test("MatB.rand values are in [0, 1)") {
+    MatB.setSeed(0L)
+    val m = MatB.rand(5, 5)
+    m.foreach { v =>
+      assert(v >= Big(0) && v < Big(1), s"out of range: $v")
+    }
+  }
+
+  test("MatB.uniform values are in [low, high)") {
+    MatB.setSeed(2L)
+    val m = MatB.uniform(-5.0, 5.0, 5, 5)
+    m.foreach { v =>
+      assert(v >= Big(-5) && v < Big(5), s"out of range: $v")
+    }
+  }
+
+  test("MatB.randint (scalar and matrix)") {
+    MatB.setSeed(7L)
+    val i = MatB.randint(0, 10)
+    assert(i >= 0 && i < 10, s"out of range: $i")
+
+    val m = MatB.randint(0, 5, 3, 3)
+    assertEquals(m.shape, (3, 3))
+  }
+
+  test("MatB.setSeed produces deterministic rand") {
+    MatB.setSeed(99L)
+    val a = MatB.rand(2, 2)
+    MatB.setSeed(99L)
+    val b = MatB.rand(2, 2)
+    assertEquals(a(0, 0), b(0, 0))
+  }
+
+  // ============================================================================
+  // MatF
+  // ============================================================================
+
+  test("MatF type alias is Mat[Float]") {
+    val m: MatF = MatF.zeros(2, 3)
+    assertEquals(m.rows, 2)
+    assertEquals(m.cols, 3)
+    assertEquals(m(0, 0), 0.0f)
+  }
+
+  test("MatF.ones / eye / full") {
+    val o = MatF.ones(2, 2)
+    assertEquals(o(0, 0), 1.0f)
+
+    val e = MatF.eye(3)
+    assertEquals(e(0, 0), 1.0f)
+    assertEquals(e(0, 1), 0.0f)
+
+    val f = MatF.full(2, 2, 5.0)
+    assertEquals(f(1, 1), 5.0f)
+  }
+
+  test("MatF.arange / linspace") {
+    val a = MatF.arange(5)
+    assertEquals(a.shape, (5, 1))
+    assertEquals(a(4, 0), 4.0f)
+
+    val l = MatF.linspace(0.0, 1.0, 3)
+    assertEquals(l.shape, (3, 1))
+    assertEquals(l(0, 0), 0.0f)
+  }
+
+  test("MatF.of / row / col / fromSeq / single") {
+    val o = MatF.of(1.0, 2.0, 3.0)
+    assertEquals(o.shape, (1, 3))
+    assertEquals(o(0, 1), 2.0f)
+
+    val r = MatF.row(4.0, 5.0)
+    assertEquals(r.shape, (1, 2))
+    assertEquals(r(0, 0), 4.0f)
+
+    val c = MatF.col(6.0, 7.0)
+    assertEquals(c.shape, (2, 1))
+    assertEquals(c(1, 0), 7.0f)
+
+    val fs = MatF.fromSeq(Seq(1.0f, 2.0f, 3.0f))
+    assertEquals(fs.shape, (3, 1))
+
+    val s = MatF.single(9.0)
+    assertEquals(s(0, 0), 9.0f)
+  }
+
+  test("MatF.tabulate") {
+    val m = MatF.tabulate(2, 3)((i, j) => (i * 3 + j).toFloat)
+    assertEquals(m(0, 0), 0.0f)
+    assertEquals(m(1, 2), 5.0f)
+  }
+
+  test("MatF.diag") {
+    val d = MatF.diag(Array(1.0f, 2.0f, 3.0f))
+    assertEquals(d.shape, (3, 3))
+    assertEquals(d(1, 1), 2.0f)
+    assertEquals(d(0, 1), 0.0f)
+  }
+
+  test("MatF.zerosLike / onesLike / fullLike") {
+    val src = MatF.full(2, 3, 7.0)
+    assertEquals(MatF.zerosLike(src)(0, 0), 0.0f)
+    assertEquals(MatF.onesLike(src)(0, 0), 1.0f)
+    assertEquals(MatF.fullLike(src, 3.0)(1, 2), 3.0f)
+  }
+
+  test("MatF.vstack / hstack") {
+    val a = MatF.ones(2, 3)
+    val b = MatF.zeros(2, 3)
+    val vs = MatF.vstack(a, b)
+    assertEquals(vs.shape, (4, 3))
+    assertEquals(vs(0, 0), 1.0f)
+    assertEquals(vs(2, 0), 0.0f)
+
+    val hs = MatF.hstack(a, b)
+    assertEquals(hs.shape, (2, 6))
+  }
+
+  test("MatF.setSeed / rand / randn / uniform / normal shapes") {
+    MatF.setSeed(42L)
+    val r  = MatF.rand(4, 5);   assertEquals(r.shape,  (4, 5))
+    val rn = MatF.randn(3, 3);  assertEquals(rn.shape, (3, 3))
+    val u  = MatF.uniform(-1.0, 1.0, 2, 4); assertEquals(u.shape, (2, 4))
+    val n  = MatF.normal(0.0, 1.0, 3, 2);   assertEquals(n.shape, (3, 2))
+  }
+
+  test("MatF.rand values are Float in [0, 1)") {
+    MatF.setSeed(0L)
+    val m = MatF.rand(5, 5)
+    m.foreach { v =>
+      assert(v >= 0.0f && v < 1.0f, s"out of range: $v")
+    }
+  }
+
+  test("MatF.uniform values are Float in [low, high)") {
+    MatF.setSeed(3L)
+    val m = MatF.uniform(-5.0, 5.0, 5, 5)
+    m.foreach { v =>
+      assert(v >= -5.0f && v < 5.0f, s"out of range: $v")
+    }
+  }
+
+  test("MatF.randint (scalar and matrix)") {
+    MatF.setSeed(7L)
+    val i = MatF.randint(0, 10)
+    assert(i >= 0 && i < 10, s"out of range: $i")
+
+    val m = MatF.randint(0, 5, 3, 3)
+    assertEquals(m.shape, (3, 3))
+  }
+
+  test("MatF.setSeed produces deterministic rand") {
+    MatF.setSeed(55L)
+    val a = MatF.rand(2, 2)
+    MatF.setSeed(55L)
+    val b = MatF.rand(2, 2)
+    assertEquals(a(0, 0), b(0, 0))
+  }
+
+  test("MatF elements are Float not Double") {
+    val m = MatF.rand(2, 2)
+    m.foreach { v =>
+      assert(v.isInstanceOf[Float], s"expected Float, got ${v.getClass}")
+    }
+  }
+}


### PR DESCRIPTION
- moved printMatrix to a separate file;
- finished adding 3 alias types `MatD`, `MatF`, and `MatB`;
- added more complete `Big` unit tests which uncovered functional gaps w.r.t. BigNaN
- renamed `BadNum` to `BigNaN`;
- combined groups of `parseDate` tests (previously one test per timestamp string) into test groups, reducing the count of datestring tests by a bit more than 600 tests

Complete rewrite of README.md to emphasize `Mat` implementation.
This is intended to be Release 0.9.1