### PR TITLE
improve documentation; update version to 0.9.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / watchTriggeredMessage := Watch.clearScreenOnTrigger
 ThisBuild / scalaVersion  := scalaVer
 
 lazy val projectName = "uni"
-ThisBuild / version       := "0.9.1" // slice machinery added but not employed
+ThisBuild / version       := "0.9.2" // slice machinery added but not employed
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"

--- a/docs/BigTypeGuide.md
+++ b/docs/BigTypeGuide.md
@@ -2,12 +2,12 @@
 
 The ```Big``` type in ```uni.Mat``` is a high-precision numeric type designed to provide the accuracy of ```BigDecimal``` with the convenience of standard numeric types. It is implemented as a Scala 3 **Opaque Type**, ensuring zero-overhead at runtime while providing a safe, custom API.
 
-## Key Concept: BadNum (The BigDecimal NaN)
+## Key Concept: BigNaN (The BigDecimal NaN)
 
-Standard ```BigDecimal``` does not have a concept of "Not a Number" (NaN). If you divide by zero or encounter an invalid string, it throws an exception. ```uni.data.Big``` introduces ```BadNum```:
+Standard ```BigDecimal``` does not have a concept of "Not a Number" (NaN). If you divide by zero or encounter an invalid string, it throws an exception. ```uni.data.Big``` introduces ```BigNaN```:
 
-* **Safe Arithmetic:** Operations involving ```BadNum``` result in ```BadNum``` (poisoning), similar to how ```Double.NaN``` works.
-* **Division Safety:** Dividing a ```Big``` value by zero returns ```BadNum``` instead of crashing your application.
+* **Safe Arithmetic:** Operations involving ```BigNaN``` result in ```BigNaN``` (poisoning), similar to how ```Double.NaN``` works.
+* **Division Safety:** Dividing a ```Big``` value by zero returns ```BigNaN``` instead of crashing your application.
 * **Validation:** Use ```n.isNaN``` or ```n.isNotNaN``` to check the validity of a result.
 
 ## Usage
@@ -17,20 +17,19 @@ Standard ```BigDecimal``` does not have a concept of "Not a Number" (NaN). If yo
 You can create ```Big``` instances from strings, integers, longs, or doubles.
 
 ```scala
-import uni.data.Big
-import uni.data.Big.*
+import uni.data.*
 
 val b1 = big("123.456")  // From String
 val b2 = 100.asBig       // Extension method
 val b3: Big = 42.0       // Implicit conversion
 
 // Extraction
-val d: Double = b1.toDouble // Returns Double.NaN if b1 is BadNum
+val d: Double = b1.toDouble // Returns Double.NaN if b1 is BigNaN
 ```
 
 ### 2. Arithmetic & Operators
 
-```Big``` supports all standard operators. If any operand is ```BadNum```, the result is ```BadNum```.
+```Big``` supports all standard operators. If any operand is ```BigNaN```, the result is ```BigNaN```.
 
 ```scala
 val result = (b1 + b2) * 2 / b3
@@ -43,7 +42,7 @@ val preciseRoot = b1.sqrt // Precise BigDecimal square root
 
 ### 3. Comparison
 
-Comparisons are "BadNum-aware." Any comparison against a ```BadNum``` returns ```false```.
+Comparisons are "BigNaN-aware." Any comparison against a ```BigNaN``` returns ```false```.
 
 ```scala
 if (b1 > b2) {
@@ -56,14 +55,14 @@ if (b1 > b2) {
 ### Construction
 | Method | Description |
 | :--- | :--- |
-| ```Big("1.23")``` | Safe parsing (returns ```BadNum``` on failure) |
+| ```Big("1.23")``` | Safe parsing (returns ```BigNaN``` on failure) |
 | ```big(1.23)``` | Lowercase factory method |
 | ```.asBig``` | Extension method for ```Int```, ```Long```, and ```Double``` |
 
 ### Safety Checks
 | Method | Description |
 | :--- | :--- |
-| ```n.isNaN``` | Returns true if the value is ```BadNum``` |
+| ```n.isNaN``` | Returns true if the value is ```BigNaN``` |
 | ```n.isNotNaN``` | Returns true if the value is a valid number |
 | ```unapply(n)``` | Allows pattern matching: ```case Big(value) => ...``` |
 
@@ -76,7 +75,7 @@ if (b1 > b2) {
 
 ## Why use Big instead of Double?
 
-Use ```Big``` when **precision is non-negotiable** (e.g., Financial calculations, high-precision weights, or any domain where floating-point rounding errors are unacceptable), but you still want the "safety-first" coding style of the NumPy/Mat ecosystem.
+Choose ```Big``` for domains where **precision is critical** (e.g., finance or high-precision weights). It avoids floating-point rounding errors while preserving an intuitive, "safety-first" coding style.
 
 ---
 © 2026 VastBlue.

--- a/docs/MatDCheatSheet.md
+++ b/docs/MatDCheatSheet.md
@@ -1,0 +1,254 @@
+# MatD Cheat Sheet
+
+Side-by-side reference for **uni.MatD**, NumPy, Breeze, R, and MATLAB.
+
+`MatD` = `Mat[Double]` — the standard double-precision matrix type in [uni.Mat](../README.md).
+
+---
+
+## Setup / Import
+
+| | Code |
+|---|---|
+| **MatD** | `import uni.data.*` |
+| **NumPy** | `import numpy as np` |
+| **Breeze** | `import breeze.linalg.*` |
+| **R** | *(built-in)* |
+| **MATLAB** | *(built-in)* |
+
+---
+
+## Matrix Creation
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| All zeros | `MatD.zeros(r, c)` | `np.zeros((r, c))` | `DenseMatrix.zeros[Double](r, c)` | `matrix(0, r, c)` | `zeros(r, c)` |
+| All ones | `MatD.ones(r, c)` | `np.ones((r, c))` | `DenseMatrix.ones[Double](r, c)` | `matrix(1, r, c)` | `ones(r, c)` |
+| Identity | `MatD.eye(n)` | `np.eye(n)` | `DenseMatrix.eye[Double](n)` | `diag(n)` | `eye(n)` |
+| From array | `MatD.from(arr, r, c)` | `np.array(lst).reshape(r, c)` | `new DenseMatrix(r, c, arr)` | `matrix(v, r, c)` | `reshape(v, r, c)` |
+| From function | `MatD.tabulate(r,c)((i,j) => f(i,j))` | `np.fromfunction(f, (r,c))` | `DenseMatrix.tabulate(r,c)(f)` | `outer(1:r, 1:c, f)` | `arrayfun(f, I, J)` |
+| Diagonal matrix | `MatD.diag(vec)` | `np.diag(v)` | `diag(v)` | `diag(v)` | `diag(v)` |
+| Zeros like | `MatD.zerosLike(m)` | `np.zeros_like(m)` | `DenseMatrix.zeros[Double](m.rows, m.cols)` | `matrix(0, nrow(m), ncol(m))` | `zeros(size(m))` |
+| Ones like | `MatD.onesLike(m)` | `np.ones_like(m)` | `DenseMatrix.ones[Double](m.rows, m.cols)` | `matrix(1, nrow(m), ncol(m))` | `ones(size(m))` |
+| Fill like | `MatD.fullLike(m, v)` | `np.full_like(m, v)` | `DenseMatrix.fill(m.rows, m.cols)(v)` | `matrix(v, nrow(m), ncol(m))` | `repmat(v, size(m))` |
+
+---
+
+## Random Generation
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Set seed | `MatD.setSeed(42)` | `np.random.seed(42)` | `RandBasis.withSeed(42)` | `set.seed(42)` | `rng(42)` |
+| Uniform [0,1) | `MatD.rand(r, c)` | `np.random.rand(r, c)` | `DenseMatrix.rand(r, c)` | `matrix(runif(r*c), r, c)` | `rand(r, c)` |
+| Standard normal | `MatD.randn(r, c)` | `np.random.randn(r, c)` | `DenseMatrix.randn(r, c)` | `matrix(rnorm(r*c), r, c)` | `randn(r, c)` |
+| Uniform [lo,hi) | `MatD.uniform(lo, hi, r, c)` | `np.random.uniform(lo, hi, (r,c))` | `DenseMatrix.rand(r,c,Uniform(lo,hi))` | `matrix(runif(r*c,lo,hi),r,c)` | `lo+(hi-lo)*rand(r,c)` |
+| Normal(μ,σ) | `MatD.normal(mu, sd, r, c)` | `np.random.normal(mu, sd, (r,c))` | `DenseMatrix.rand(r,c,Gaussian(mu,sd))` | `matrix(rnorm(r*c,mu,sd),r,c)` | `mu+sd*randn(r,c)` |
+| Random ints | `MatD.randint(lo, hi, r, c)` | `np.random.randint(lo, hi, (r,c))` | `DenseMatrix.rand(r,c,...).map(_.toInt)` | `matrix(sample(lo:hi,r*c,T),r,c)` | `randi([lo hi-1],r,c)` |
+
+> **Note:** `MatD.setSeed` / `MatD.rand` / `MatD.randn` / `MatD.uniform` use a 100% faithful PCG64 implementation matching NumPy's output bit-for-bit.
+
+---
+
+## Shape and Info
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Dimensions | `m.shape` → `(r, c)` | `m.shape` | `(m.rows, m.cols)` | `dim(m)` | `size(m)` |
+| Row count | `m.rows` | `m.shape[0]` | `m.rows` | `nrow(m)` | `size(m,1)` |
+| Col count | `m.cols` | `m.shape[1]` | `m.cols` | `ncol(m)` | `size(m,2)` |
+| Total elements | `m.rows * m.cols` | `m.size` | `m.size` | `length(m)` | `numel(m)` |
+
+---
+
+## Indexing and Slicing
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Single element | `m(i, j)` | `m[i, j]` | `m(i, j)` | `m[i+1, j+1]` | `m(i+1, j+1)` |
+| Row slice (view) | `m(i, ::)` | `m[i, :]` | `m(i, ::)` | `m[i+1,]` | `m(i+1,:)` |
+| Column slice (view) | `m(::, j)` | `m[:, j]` | `m(::, j)` | `m[,j+1]` | `m(:,j+1)` |
+| Transpose (O(1)) | `m.T` or `m.transpose` | `m.T` | `m.t` | `t(m)` | `m'` |
+
+> MatD slices are **zero-indexed views** with O(1) cost (no data copy), matching NumPy's strided semantics.
+
+---
+
+## Element-wise Arithmetic
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Add matrices | `a + b` | `a + b` | `a + b` | `a + b` | `a + b` |
+| Subtract | `a - b` | `a - b` | `a - b` | `a - b` | `a - b` |
+| Multiply (Hadamard) | `a * b` | `a * b` | `a :* b` | `a * b` | `a .* b` |
+| Divide | `a / b` | `a / b` | `a :/ b` | `a / b` | `a ./ b` |
+| Add scalar | `a + 2.0` | `a + 2.0` | `a + 2.0` | `a + 2` | `a + 2` |
+| Multiply scalar | `a * 3.0` | `a * 3.0` | `a * 3.0` | `a * 3` | `a * 3` |
+
+---
+
+## Matrix Multiplication
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Matrix multiply | `a ~@ b` | `a @ b` | `a * b` | `a %*% b` | `a * b` |
+
+---
+
+## In-place Operations
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Add scalar in-place | `m :+= 2.0` | `m += 2.0` | `m :+= 2.0` | `m[] <- m + 2` | `m = m + 2` |
+| Subtract scalar | `m :-= 1.0` | `m -= 1.0` | `m :-= 1.0` | `m[] <- m - 1` | `m = m - 1` |
+| Multiply scalar | `m :*= 3.0` | `m *= 3.0` | `m :*= 3.0` | `m[] <- m * 3` | `m = m * 3` |
+| Divide scalar | `m :/= 2.0` | `m /= 2.0` | `m :/= 2.0` | `m[] <- m / 2` | `m = m / 2` |
+| Add matrix in-place | `m :+= n` | `m += n` | `m :+= n` | `m[] <- m + n` | `m = m + n` |
+
+---
+
+## Reductions
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Sum all | `m.sum` | `m.sum()` | `sum(m)` | `sum(m)` | `sum(m(:))` |
+| Mean all | `m.mean` | `m.mean()` | `mean(m)` | `mean(m)` | `mean(m(:))` |
+| Min all | `m.min` | `m.min()` | `min(m)` | `min(m)` | `min(m(:))` |
+| Max all | `m.max` | `m.max()` | `max(m)` | `max(m)` | `max(m(:))` |
+
+---
+
+## Element-wise Math
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Absolute value | `m.map(_.abs)` | `np.abs(m)` | `abs(m)` | `abs(m)` | `abs(m)` |
+| Square root | `m.map(math.sqrt)` | `np.sqrt(m)` | `sqrt(m)` | `sqrt(m)` | `sqrt(m)` |
+| Exponential | `m.map(math.exp)` | `np.exp(m)` | `exp(m)` | `exp(m)` | `exp(m)` |
+| Log | `m.map(math.log)` | `np.log(m)` | `log(m)` | `log(m)` | `log(m)` |
+| Power (scalar) | `m.map(math.pow(_, p))` | `m ** p` | `m ^:^ p` | `m ^ p` | `m .^ p` |
+| Map arbitrary fn | `m.map(f)` | `np.vectorize(f)(m)` | `m.map(f)` | `apply(m, c(1,2), f)` | `arrayfun(f, m)` |
+
+---
+
+## Activation Functions
+
+| Operation | MatD | NumPy / SciPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| ReLU | `m.relu` | `np.maximum(m, 0)` | `max(m, 0.0)` | `pmax(m, 0)` | `max(m, 0)` |
+| Sigmoid | `m.sigmoid` | `scipy.special.expit(m)` | `sigmoid(m)` | `1/(1+exp(-m))` | `1./(1+exp(-m))` |
+| Softmax | `m.softmax` | `scipy.special.softmax(m)` | `softmax(m)` | `exp(m)/sum(exp(m))` | `exp(m)./sum(exp(m))` |
+| Leaky ReLU | `m.leakyRelu` | `np.where(m>0, m, 0.01*m)` | — | `ifelse(m>0, m, 0.01*m)` | `max(0.01*m, m)` |
+
+---
+
+## Boolean / Masking
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Element comparison | `m :== 0.0` → `Mat[Boolean]` | `m == 0` | `m :== 0.0` | `m == 0` | `m == 0` |
+| Negate mask | `!mask` | `~mask` | `!mask` | `!mask` | `~mask` |
+| Count true | `mask.sum` | `mask.sum()` | `sum(mask)` | `sum(mask)` | `sum(mask(:))` |
+| Any true | `mask.any` | `mask.any()` | `any(mask)` | `any(mask)` | `any(mask(:))` |
+| All true | `mask.all` | `mask.all()` | `all(mask)` | `all(mask)` | `all(mask(:))` |
+| Conditional select | `Mat.where(cond, x, y)` | `np.where(cond, x, y)` | `where(cond, x, y)` | `ifelse(cond, x, y)` | `cond.*x + ~cond.*y` |
+
+---
+
+## Stacking and Splitting
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Stack rows | `MatD.vstack(a, b)` | `np.vstack([a, b])` | `DenseMatrix.vertcat(a, b)` | `rbind(a, b)` | `[a; b]` |
+| Stack cols | `MatD.hstack(a, b)` | `np.hstack([a, b])` | `DenseMatrix.horzcat(a, b)` | `cbind(a, b)` | `[a, b]` |
+| Split rows | `m.vsplit(n)` | `np.vsplit(m, n)` | — | — | `mat2cell(m, repmat(r/n,1,n), c)` |
+| Split cols | `m.hsplit(n)` | `np.hsplit(m, n)` | — | — | `mat2cell(m, r, repmat(c/n,1,n))` |
+
+---
+
+## Signal Processing (1-D Vectors)
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Polynomial fit | `MatD.polyfit(x, y, deg)` | `np.polyfit(x, y, deg)` | — | `lm(y ~ poly(x, deg))` | `polyfit(x, y, deg)` |
+| Polynomial eval | `MatD.polyval(coeffs, x)` | `np.polyval(coeffs, x)` | — | `predict(fit, ...)` | `polyval(coeffs, x)` |
+| Convolve | `MatD.convolve(a, b)` | `np.convolve(a, b)` | `convolve(a, b)` | `convolve(a, b)` | `conv(a, b)` |
+| Correlate | `MatD.correlate(a, b)` | `np.correlate(a, b)` | — | `ccf(a, b)` | `xcorr(a, b)` |
+| Meshgrid | `MatD.meshgrid(x, y)` | `np.meshgrid(x, y)` | — | `expand.grid(x, y)` | `meshgrid(x, y)` |
+
+---
+
+## Display and Formatting
+
+| Operation | MatD | NumPy | Breeze | R | MATLAB |
+|---|---|---|---|---|---|
+| Print default | `println(m)` | `print(m)` | `println(m)` | `print(m)` | `disp(m)` |
+| Explicit show | `m.show` | `str(m)` | `m.toString` | `print(m)` | `disp(m)` |
+| Custom format | `m.show("%.2f")` | `np.set_printoptions(...)` | — | `format(m, digits=2)` | `format short` |
+| Set thresholds | `Mat.setPrintOptions(maxRows=20, maxCols=20, edgeItems=5)` | `np.set_printoptions(threshold=...)` | — | `options(max.print=...)` | `format compact` |
+
+---
+
+## Quick Reference Card
+
+```scala
+import uni.data.*
+
+// Create
+val a = MatD.zeros(3, 4)
+val b = MatD.randn(3, 4)
+val c = MatD.eye(3)
+
+// Seed + random (100% NumPy-compatible)
+MatD.setSeed(42)
+val w = MatD.uniform(-0.1, 0.1, 64, 32)
+
+// Slice (zero-indexed, O(1) views)
+val row0 = b(0, ::)   // first row
+val col0 = b(::, 0)   // first column
+val bT   = b.T        // transpose
+
+// Arithmetic
+val d = a + b         // element-wise
+val e = a * b         // Hadamard product
+val f = c ~@ b        // matmul
+
+// In-place
+b :*= 0.5
+b :+= a
+
+// Activations
+val g = f.sigmoid
+val h = f.relu
+
+// Reductions
+val s = b.sum
+val u = b.mean
+
+// Boolean
+val mask = (b :== 0.0) || (b :== 1.0)
+val inv  = !mask
+val hits = mask.sum
+
+// Conditional
+val r = Mat.where(mask, 1.0, 0.0)
+
+// Stack / split
+val tall = MatD.vstack(a, b)
+val halves = tall.vsplit(2)   // Seq[MatD]
+
+// Display
+println(b.show("%.4f"))
+Mat.setPrintOptions(maxRows = 20, maxCols = 20, edgeItems = 5)
+```
+
+---
+
+## Type Aliases Summary
+
+| Alias | Full Type | Factory Object | Notes |
+|---|---|---|---|
+| `MatD` | `Mat[Double]` | `MatD` | Default, IEEE 754 double |
+| `MatF` | `Mat[Float]` | `MatF` | Half the memory of MatD |
+| `MatB` | `Mat[Big]` | `MatB` | Arbitrary precision, NaN-safe |
+
+All three share the same API; factory objects mirror `Mat` methods with appropriate types.

--- a/jsrc/colN.sc
+++ b/jsrc/colN.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.io.*

--- a/jsrc/convertCsvToData.sc
+++ b/jsrc/convertCsvToData.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.time.*

--- a/jsrc/csvClient.sc
+++ b/jsrc/csvClient.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import java.nio.charset.StandardCharsets
 import uni.*

--- a/jsrc/csvClientRows.sc
+++ b/jsrc/csvClientRows.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 //import uni.fs.*

--- a/jsrc/csvEachRow.sc
+++ b/jsrc/csvEachRow.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.Paths
 import uni.io.*

--- a/jsrc/csvMinimizeQuotes.sc
+++ b/jsrc/csvMinimizeQuotes.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.io.*

--- a/jsrc/dataFrame.sc
+++ b/jsrc/dataFrame.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.time.*

--- a/jsrc/dateTester.sc
+++ b/jsrc/dateTester.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.time.*

--- a/jsrc/delimiterCheck.sc
+++ b/jsrc/delimiterCheck.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 //package uni
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.io.*

--- a/jsrc/fastHash64.sc
+++ b/jsrc/fastHash64.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.io.Hash64.hash64

--- a/jsrc/genTestPaths.sc
+++ b/jsrc/genTestPaths.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 import uni.*
 
 object GenTestPaths {

--- a/jsrc/generateDetailedDocs.sc
+++ b/jsrc/generateDetailedDocs.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
 //> using dep com.lihaoyi::os-lib:0.11.3
-//> using dep org.vastblue:uni_3:0.7.0
+//> using dep org.vastblue:uni_3:0.9.2
 
 import scala.io.Source
 import scala.collection.mutable

--- a/jsrc/generateDocs.sc
+++ b/jsrc/generateDocs.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
 //> using dep com.lihaoyi::os-lib:0.11.3
-//> using dep org.vastblue:uni_3:0.7.0
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import scala.io.Source

--- a/jsrc/hereDoc.sc
+++ b/jsrc/hereDoc.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import java.nio.file.{Files as JFiles, Paths as JPaths, Path as JPath}

--- a/jsrc/importOrder.sc
+++ b/jsrc/importOrder.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import java.nio.file.Path
 

--- a/jsrc/loadCsv.sc
+++ b/jsrc/loadCsv.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.9.1
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.data.*

--- a/jsrc/mUntil.sc
+++ b/jsrc/mUntil.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.data.*
 import Mat.*

--- a/jsrc/matD.sc
+++ b/jsrc/matD.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -deprecation
 
-//> using dep org.vastblue:uni_3:0.9.1
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.data.*
 //import uni.data.Mat.*

--- a/jsrc/matStuff.sc
+++ b/jsrc/matStuff.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -deprecation
 //package apps
 
-//> using dep org.vastblue:uni_3:0.9.1
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.data.*
 import uni.data.Mat.*

--- a/jsrc/minimizeQuotes.sc
+++ b/jsrc/minimizeQuotes.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.* // {Path, Paths}
 import uni.io.* // {FastCsv, CsvWriter, Delimiter}

--- a/jsrc/myPath.sc
+++ b/jsrc/myPath.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 

--- a/jsrc/numpy2mat.sc
+++ b/jsrc/numpy2mat.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
 //> using dep com.lihaoyi::ujson::4.0.2
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import scala.collection.mutable
@@ -142,7 +142,7 @@ print(json.dumps(node_to_dict(tree), indent=2))
   private def renderOutput(lines: Seq[String], ctx: TranslateContext): String =
     val scriptHeader = """#!/usr/bin/env -S scala-cli shebang -deprecation
       |
-      |//> using dep org.vastblue:uni_3:0.8.2""".trim.stripMargin
+      |//> using dep org.vastblue:uni_3:0.9.2""".trim.stripMargin
 
     val sb = new StringBuilder
     sb.append(scriptHeader+"\n")

--- a/jsrc/parseDate.sc
+++ b/jsrc/parseDate.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 //import uni.{showUsage, eachArg, thisArg}
 import uni.*

--- a/jsrc/progname.sc
+++ b/jsrc/progname.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 

--- a/jsrc/readFstab.sc
+++ b/jsrc/readFstab.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 //import uni.fs.* // useful extensions

--- a/jsrc/realPath.sc
+++ b/jsrc/realPath.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import java.nio.file.Files

--- a/jsrc/repl.sc
+++ b/jsrc/repl.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala-cli repl
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 import uni.*
 import uni.time.*
 import uni.data.*

--- a/jsrc/rng.sc
+++ b/jsrc/rng.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.data.*
 

--- a/jsrc/show.sc
+++ b/jsrc/show.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 import uni.*
 import uni.time.*
 import uni.data.*
@@ -92,4 +92,3 @@ object Main:
   // unsupported expr: JoinedStr
   // np.random.normal - not yet translated
   // np.random.normal - not yet translated
-

--- a/jsrc/sortByCols.sc
+++ b/jsrc/sortByCols.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 //import uni.fs.*

--- a/jsrc/ujtest.sc
+++ b/jsrc/ujtest.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
 //> using dep com.lihaoyi::ujson::4.0.2
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import scala.collection.mutable

--- a/jsrc/updateVersion.sc
+++ b/jsrc/updateVersion.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import java.nio.file.*
 import scala.jdk.CollectionConverters.*

--- a/jsrc/usage.sc
+++ b/jsrc/usage.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 

--- a/jsrc/verifyTestDates.sc
+++ b/jsrc/verifyTestDates.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 import uni.time.*

--- a/jsrc/winpath.sc
+++ b/jsrc/winpath.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 
-//> using dep org.vastblue:uni_3:0.8.2
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 //import uni.fs.*

--- a/src/main/scala/apps/MatDCheck.scala
+++ b/src/main/scala/apps/MatDCheck.scala
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala-cli shebang -deprecation
 package apps
 
-//> using dep org.vastblue:uni_3:0.9.1
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.data.*
 import uni.data.Mat.*

--- a/src/main/scala/apps/MatrixFromCsv.scala
+++ b/src/main/scala/apps/MatrixFromCsv.scala
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala-cli shebang -Wunused:imports -Wunused:locals -deprecation
 package apps
 
-//> using dep org.vastblue:uni_3:0.9.1
+//> using dep org.vastblue:uni_3:0.9.2
 
 import uni.*
 

--- a/src/main/scala/uni/data/Big.scala
+++ b/src/main/scala/uni/data/Big.scala
@@ -5,8 +5,10 @@ import scala.math.BigDecimal
 import scala.math.BigDecimal.*
 export scala.math.BigDecimal.RoundingMode
 
-export Big.Big
+export Big.{Big, big, asBig, zero, one, ten, hundred}
+//export Big.*
 
+// Mat
 object Big:
   private val MC = java.math.MathContext.DECIMAL128   // or a custom context
   // ------------------------------------------------------------
@@ -29,12 +31,18 @@ object Big:
   def apply(l: Long): Big        = BigDecimal(l)
   def apply(bd: BigDecimal): Big = bd
 
+  def big(str: String): Big      = str2num(str)
+  def big(d: Double): Big        = BigDecimal(d)
+  def big(i: Int): Big           = BigDecimal(i)
+  def big(l: Long): Big          = BigDecimal(l)
+  def big(bd: BigDecimal): Big   = bd.asInstanceOf[Big]
+
   // Lowercase factory (public API)
-  def big(s: String): Big      = apply(s)
-  def big(d: Double): Big      = apply(d)
-  def big(i: Int): Big         = apply(i)
-  def big(l: Long): Big        = apply(l)
-  def big(bd: BigDecimal): Big = apply(bd)
+//  def big(s: String): Big      = apply(s)
+//  def big(d: Double): Big      = apply(d)
+//  def big(i: Int): Big         = apply(i)
+//  def big(l: Long): Big        = apply(l)
+//  def big(bd: BigDecimal): Big = apply(bd)
 
   // ------------------------------------------------------------
   // Extractor for pattern matching
@@ -50,6 +58,9 @@ object Big:
   // given Conversion[Long, Big] = l => Big(BigDecimal(l))
   // given Conversion[Int, Big]  = i => Big(BigDecimal(i))
   // given Conversion[Double, Big] = d => Big(BigDecimal(d))
+
+  extension (s: String)
+    inline def asBig: Big = Big(BigDecimal(s))
 
   extension (d: Double)
     inline def asBig: Big = Big(BigDecimal(d))

--- a/src/main/scala/uni/data/BigUtils.scala
+++ b/src/main/scala/uni/data/BigUtils.scala
@@ -173,11 +173,13 @@ object BigUtils:
   // Big constructors (explicit, minimal)
   // ------------------------------------------------------------
 
-  def big(str: String): Big = str2num(str)
-  def big(bd: Big): Big = bd
-  def big(d: Double): Big = Big(d)
-  def big(i: Int): Big = Big(i)
-  def big(l: Long): Big = Big(l)
+  /*
+  def big(s: String): Big      = apply(s)
+  def big(d: Double): Big      = apply(d)
+  def big(i: Int): Big         = apply(i)
+  def big(l: Long): Big        = apply(l)
+  def big(bd: BigDecimal): Big = apply(bd)
+  */
 
   // ------------------------------------------------------------
   // Formatting DSL core

--- a/src/main/scala/uni/data/Mat.scala
+++ b/src/main/scala/uni/data/Mat.scala
@@ -7,7 +7,7 @@ import uni.io.FileOps.*
 //export Mat.MatD as MatD
 import uni.data.Big.Big
 export Mat.Mat
-export Mat.{rows, cols, shape, size, isEmpty, transposed, isContiguous, apply, isNaN, isNotNaN}
+export Mat.{rows, cols, shape, size, isEmpty, transposed, isContiguous, apply}
 
 
 //type MatD = Mat.MatD.type
@@ -107,8 +107,7 @@ object Mat {
     }
 
   extension (m: Mat[Big])
-    def isNaN: Mat[Boolean] = m.map(_ == BigUtils.BigNaN)
-    def isNotNaN: Mat[Boolean] = m.map(_ != BigUtils.BigNaN)
+    def hasNaN: Mat[Boolean] = m.map(_ == BigUtils.BigNaN)
 
   private object Internal {
     class MatData[T] private[Internal](


### PR DESCRIPTION
Updated documentation:
  - Setup/imports for all 5 platforms
  - Creation — zeros, ones, eye, tabulate, diag, zeros/ones/fullLike
  - Random — seed, rand, randn, uniform, normal, randint (with PCG64 note)
  - Shape/info — shape, rows, cols, size
  - Indexing — element, row slice, column slice, transpose (with O(1) note)
  - Arithmetic — element-wise, matrix multiply (~@ vs @ vs %*%)
  - In-place ops — :+=, :-=, :*=, :/=
  - Reductions — sum, mean, min, max
  - Element-wise math — abs, sqrt, exp, log, power, map
  - Activations — relu, sigmoid, softmax, leakyRelu
  - Boolean/masking — comparison, negation, any/all, Mat.where
  - Stacking/splitting — vstack, hstack, vsplit, hsplit
  - Signal processing — polyfit, polyval, convolve, correlate, meshgrid
  - Display — show, format string, setPrintOptions
  - Quick reference card — self-contained runnable snippet
  - Type aliases table — MatD / MatF / MatB summary